### PR TITLE
The image src should be ng-src for angular

### DIFF
--- a/src/demo/main.js
+++ b/src/demo/main.js
@@ -79,7 +79,7 @@ app.controller('CarouselDemoCtrl', ['$scope', 'Carousel', function($scope, Carou
     '  <!-- For slider render -->\n' +
     '  <carousel-item>\n' +
     '    <!-- placed your item content here -->\n' +
-    '    <img src="{{ item.image }}" alt="{{ item.title }}" />\n' +
+    '    <img ng-src="{{ item.image }}" alt="{{ item.title }}" />\n' +
     '    <h3> {{ item.name }} </h3>\n' +
     '    <p> {{ item.description }} </h3>\n' +
     '    <!-- end -->\n' +


### PR DESCRIPTION
Request will be send like this: somedoamin.com/`%7B%7B%20item%20%7D%7D`
After decode, you can find: `%7B%7B%20item%20%7D%7D` is `{{item}}`, after this fix, the error will be gone. 
Even on [liveDemo](https://mihnsen.github.io/ui-carousel/) you can find error also. 